### PR TITLE
Assign device to user

### DIFF
--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -1,4 +1,15 @@
 class Device < ApplicationRecord
-  has_one :device_assignment, -> { where(returned: false) }, class_name: "DeviceAssignment"
-  belongs_to :user
+  has_many :device_assignments, dependent: :destroy
+
+  has_one :active_device_assignment,
+          -> { where(returned: false) },
+          class_name: "DeviceAssignment"
+
+  has_one :current_user,
+          through: :active_device_assignment,
+          source: :user
+
+  belongs_to :user, optional: true
+
+  validates :serial_number, presence: true, uniqueness: true
 end

--- a/app/models/device_assignment.rb
+++ b/app/models/device_assignment.rb
@@ -4,6 +4,19 @@ class DeviceAssignment < ApplicationRecord
   belongs_to :user
   belongs_to :device
 
+  validates :user_id, presence: true
   validates :device_id, presence: true
-  validates :device_id, uniqueness: { scope: :user_id, message: "The device with id:  " + :device_id.to_s + " is already assigned to user with id:  " + :user_id.to_s }
+  validates :device_id,
+            uniqueness: {
+              scope: [:user_id],
+              conditions: -> { where(returned: false) },
+              message: "This device is already assigned to this user and has not been returned."
+            }
+
+  scope :returned, -> { where(returned: true) }
+  scope :active, -> { where(returned: false) }
+
+  def not_returned?
+    !returned
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,21 @@
 class User < ApplicationRecord
-  has_many :device_assignments, dependent: :destroy
-  has_many :devices, through: :device_assignments
-  has_many :api_keys, as: :bearer
   has_secure_password
 
+  has_many :device_assignments, dependent: :destroy
+  has_many :devices, through: :device_assignments
+
+  has_many :active_device_assignments,
+           -> { where(device_assignments: { returned: false }) },
+           through: :device_assignments,
+           source: :device
+
+  has_many :returned_devices,
+           -> { where(device_assignments: { returned: true }) },
+           through: :device_assignments,
+           source: :device
+
+  has_many :api_keys, as: :bearer
+
+  validates :username, presence: true, uniqueness: true
+  validate :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
 end

--- a/app/services/assign_device_to_user.rb
+++ b/app/services/assign_device_to_user.rb
@@ -13,6 +13,7 @@ class AssignDeviceToUser
     validate_inputs!
     future_device_owner = find_new_device_owner
     compare_requesting_user_and_new_device_owner(future_device_owner)
+    device = find_device_by_serial_number
   end
 
   private
@@ -32,5 +33,10 @@ class AssignDeviceToUser
     unless requesting_user == new_device_owner
       raise ArgumentError, "You can't assign a device to someone else, just to yourself"
     end
+  end
+
+  def find_device_by_serial_number
+    Device.find_by(serial_number: serial_number) ||
+      raise(ActiveRecord::RecordNotFound, "No device with serial number #{serial_number}")
   end
 end

--- a/app/services/assign_device_to_user.rb
+++ b/app/services/assign_device_to_user.rb
@@ -11,8 +11,9 @@ class AssignDeviceToUser
 
   def call
     validate_inputs!
+    future_device_owner = find_new_device_owner
+    compare_requesting_user_and_new_device_owner(future_device_owner)
   end
-
 
   private
 
@@ -20,5 +21,16 @@ class AssignDeviceToUser
     raise ArgumentError, "No user" if requesting_user.nil?
     raise ArgumentError, "No serial number" if serial_number.nil?
     raise ArgumentError, "No id of the owner" if new_device_owner_id.zero?
+  end
+
+  def find_new_device_owner
+    User.find_by(id: new_device_owner_id) ||
+      raise(ActiveRecord::RecordNotFound, "No user with id #{new_device_owner_id}")
+  end
+
+  def compare_requesting_user_and_new_device_owner(new_device_owner)
+    unless requesting_user == new_device_owner
+      raise ArgumentError, "You can't assign a device to someone else, just to yourself"
+    end
   end
 end

--- a/app/services/assign_device_to_user.rb
+++ b/app/services/assign_device_to_user.rb
@@ -2,6 +2,7 @@
 
 class AssignDeviceToUser
   attr_reader :requesting_user, :serial_number, :new_device_owner_id
+
   def initialize(requesting_user:, serial_number:, new_device_owner_id:)
     @requesting_user = requesting_user
     @serial_number = serial_number
@@ -9,6 +10,15 @@ class AssignDeviceToUser
   end
 
   def call
+    validate_inputs!
   end
 
+
+  private
+
+  def validate_inputs!
+    raise ArgumentError, "No user" if requesting_user.nil?
+    raise ArgumentError, "No serial number" if serial_number.nil?
+    raise ArgumentError, "No id of the owner" if new_device_owner_id.zero?
+  end
 end

--- a/app/services/assign_device_to_user.rb
+++ b/app/services/assign_device_to_user.rb
@@ -11,10 +11,15 @@ class AssignDeviceToUser
 
   def call
     validate_inputs!
+
     future_device_owner = find_new_device_owner
     compare_requesting_user_and_new_device_owner(future_device_owner)
+
     device = find_device_by_serial_number
+
     check_if_user_assigned_device_before!(future_device_owner, device)
+
+    assign_device_to_user(future_device_owner, device)
   end
 
   private
@@ -44,6 +49,15 @@ class AssignDeviceToUser
   def check_if_user_assigned_device_before!(user, device)
     if DeviceAssignment.find_by(user: user, device: device, returned: true)
       raise ActiveRecord::RecordNotUnique, "You already assigned to this device once, you can't do it again"
+    end
+  end
+
+  def assign_device_to_user(user, device)
+    assignment = DeviceAssignment.new(user: user, device: device, returned: false)
+    if assignment.save
+      assignment
+    else
+      raise "Assignment failed"
     end
   end
 end

--- a/app/services/assign_device_to_user.rb
+++ b/app/services/assign_device_to_user.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
 class AssignDeviceToUser
+  attr_reader :requesting_user, :serial_number, :new_device_owner_id
   def initialize(requesting_user:, serial_number:, new_device_owner_id:)
+    @requesting_user = requesting_user
+    @serial_number = serial_number
+    @new_device_owner_id = new_device_owner_id.to_i
   end
 
   def call
   end
+
 end


### PR DESCRIPTION
AssignDeviceToUser Service:

- Created a service to assign a device to a user based on a serial number and user ID.

- Validates the presence of the requesting user and serial number before proceeding.

- Checks if the user is allowed to assign the device to themselves (no cross-user assignment).

- Handles the creation of DeviceAssignment with proper validations (device not assigned to another user, device not previously returned).

- Adds handling for potential errors during the assignment process (e.g., device already assigned or returned).

Model Changes:
User, Device, DeviceAssignment - validation and relationships changes